### PR TITLE
added support for tempalte variables inside quickcrumb templates

### DIFF
--- a/_build/build.transport.php
+++ b/_build/build.transport.php
@@ -4,7 +4,7 @@
  *
  * @package QuickCrumbs
  * @version 1.0.0
- * @release beta2
+ * @release beta3
  * @author Jason Coward <jason@modx.com>
  */
 $mtime = microtime();
@@ -17,7 +17,7 @@ set_time_limit(0);
 define('PKG_NAME','quickcrumbs');
 define('PKG_NAME_LOWER',strtolower(PKG_NAME));
 define('PKG_VERSION','1.0.0');
-define('PKG_RELEASE','beta2');
+define('PKG_RELEASE','beta3');
 
 /* define sources */
 $root = dirname(dirname(__FILE__)) . '/';

--- a/_build/properties.inc.php
+++ b/_build/properties.inc.php
@@ -42,6 +42,13 @@ $properties = array(
         'value' => 'pagetitle,menutitle,description',
     ),
     array(
+        'name' => 'tvs',
+        'desc' => 'The template variables to get from the resource as placeholders; Example: mytv; NOTE to use inside template use tv. as prefix, so for mytv the placeholder becomes tv.mytv',
+        'type' => 'textfield',
+        'options' => '',
+        'value' => '',
+    ),
+    array(
         'name' => 'showSiteStart',
         'desc' => 'If true, will render the site_start resource as a crumb. (DEFAULT: true)',
         'type' => 'combo-boolean',

--- a/core/components/quickcrumbs/docs/changelog.txt
+++ b/core/components/quickcrumbs/docs/changelog.txt
@@ -1,5 +1,9 @@
 Changelog for QuickCrumbs.
 
+QuickCrumbs 1.0.0-beta3 (January 6, 2011)
+====================================
+- [#1] Added support for template variables
+
 QuickCrumbs 1.0.0-beta2 (October 19, 2010)
 ====================================
 - [#2] Allow empty separator property

--- a/core/components/quickcrumbs/quickcrumbs.snippet.php
+++ b/core/components/quickcrumbs/quickcrumbs.snippet.php
@@ -21,7 +21,7 @@
  */
 /**
  * A quick and efficient bread crumbs Snippet for MODx Revolution.
- * 
+ *
  * @package quickcrumbs
  */
 $output = array();
@@ -31,6 +31,9 @@ $fields = empty($fields) ? 'pagetitle,menutitle,description' : $fields;
 $fields = explode(',', $fields);
 foreach ($fields as $fieldKey => $field) $fields[$fieldKey] = trim($field);
 array_unshift($fields, 'id', 'class_key', 'context_key');
+$tvs = empty($tvs) ? '' : $tvs;
+$tvs = explode(',', $tvs);
+foreach ($tvs as $tvKey => $tv) $tvs[$tvKey] = trim($tv);
 $parents = $modx->getParentIds($resourceId);
 array_pop($parents);
 $parents = array_reverse($parents);
@@ -57,6 +60,9 @@ if (!empty($parents)) {
         }
         if ($object) {
             $properties = array_merge($scriptProperties, $object->get($fields));
+			foreach ($tvs as $tvKey => $tv) {
+				$properties = array_merge($properties, array('tv.'.$tv => $object->getTVValue($tv)));
+			}
             if ((integer) $parent == $siteStart) {
                 if (!empty($showSiteStart)) {
                     if (!empty($siteStartTpl)) {
@@ -81,6 +87,9 @@ if (!empty($parents)) {
 }
 if (!empty($showSelf) && !($resourceId == $siteStart && !empty($showSiteStart))) {
     $properties = array_merge($scriptProperties, $modx->resource->get($fields));
+	foreach ($tvs as $tvKey => $tv) {
+		$properties = array_merge($properties, array('tv.'.$tv => $modx->resource->getTVValue($tv)));
+	}
     if (!empty($selfTpl)) {
         $output[] = $modx->getChunk($selfTpl, $properties);
     } else {
@@ -92,6 +101,9 @@ if (!empty($showSiteStart) && !$siteStartShown) {
     $query->select($modx->getSelectColumns('modResource', '', '', $fields));
     $siteStartResource = $modx->getObject('modResource', $query);
     $properties = array_merge($scriptProperties, $siteStartResource->get($fields));
+	foreach ($tvs as $tvKey => $tv) {
+		$properties = array_merge($properties, array('tv.'.$tv => $siteStartResource->getTVValue($tv)));
+	}
     if (!empty($siteStartTpl)) {
         $siteStartOutput = $modx->getChunk($siteStartTpl, $properties);
     } else {


### PR DESCRIPTION
Example:
<code>[[QuickCrumbs? &tpl=&#96;mycrumb&#96; &tvs=&#96;mytv,mytvdesc&#96;]]</code>

Template:
<code>&lt;a href="[[~[[+id]]]]" title="[[+tv.mytvdesc]]"&gt;[[+tv.mytv]]&lt;/a&gt;</code>
