### PR TITLE
add the ability to hide specific resources by ID

### DIFF
--- a/_build/properties.inc.php
+++ b/_build/properties.inc.php
@@ -111,6 +111,13 @@ $properties = array(
         'options' => '',
         'value' => false
     ),
+    array(
+        'name' => 'hideIds',
+        'desc' => 'A list of resource IDs you want to hide from the breadcrumbs.',
+        'type' => 'textfield',
+        'options' => '',
+        'value' => '',
+    ),
 );
 
 return $properties;

--- a/core/components/quickcrumbs/quickcrumbs.snippet.php
+++ b/core/components/quickcrumbs/quickcrumbs.snippet.php
@@ -56,6 +56,9 @@ if (!empty($parents)) {
             'class_key:NOT IN' => array('modWebLink', 'modSymLink')
         ));
     }
+    if (!empty($hideIds)) {
+        $query->where(array('id:NOT IN' => explode(',', $hideIds)));
+    }
     $query->select($modx->getSelectColumns('modResource', '', '', $fields));
     $collection = $modx->getCollection('modResource', $query);
     $parent = reset($parents);


### PR DESCRIPTION
I need this on a web site I am working and it seems like a rather fairly common use-case. Thought to contribute the change back to you.

Use case: I have a blog with numerous posts structured like this:

Blog (the main page with the latest posts)
- Some pages
- Articles
  - The blog posts themselves, with tags and such.

Articles is just a container, like categories, but I don't want in my site the concept of categories _and_ tags - I only want the latter. So, I am hiding the container "articles".

Thanks!
