### PR TITLE
Fix for adding $self to output despite $showSelf set to `0`

### DIFF
--- a/core/components/quickcrumbs/quickcrumbs.snippet.php
+++ b/core/components/quickcrumbs/quickcrumbs.snippet.php
@@ -113,6 +113,8 @@ if (!empty($parents)) {
                     } else {
                         $output[] = "<pre>" . print_r($properties, true) . "</pre>";
                     }
+                } elseif ($self && !$showSelf) {
+                    //do nothing
                 } else {
                     $parentTitles[] = $properties['pagetitle'];
                     if (!empty($tpl)) {


### PR DESCRIPTION
There must be a better way to do this, but without this addition, &showSelf=`0` has no effect.