### PR TITLE
the ability to add resourceId in snippet properties.

### DIFF
--- a/core/components/quickcrumbs/quickcrumbs.snippet.php
+++ b/core/components/quickcrumbs/quickcrumbs.snippet.php
@@ -26,7 +26,8 @@
  */
 $output = array();
 $parentTitles = array();
-$resourceId = (integer) $modx->resource->get('id');
+if(!$resourceId){
+$resourceId = (integer) $modx->resource->get('id');}
 $fields = empty($fields) ? 'pagetitle,menutitle,description' : $fields;
 $fields = explode(',', $fields);
 foreach ($fields as $fieldKey => $field) $fields[$fieldKey] = trim($field);


### PR DESCRIPTION
en
if page with this snippet not in 'modx_site_content' table (for example products for Shopkeeper ), or if it's need output crumb for another page.
Example  call snippet `<div class="container">
         <ol class="breadcrumb">
          [[QuickCrumbs?
          &tpl=`Crumb` 
          &selfTpl=`Crumb` 
          &siteStartTpl=`Crumb` 
          &separator=`` 
          &hideEmptyContainers=`0` 
          &showSiteStart=`1` 
          &resourceId=`[[*resource_id]]`]]
          <li class="active">[[*pagetitle]]</li>
         </ol> </div>`

ru
Если страница со сниппетом не является ресурсом modx (не в таблице 'modx_site_content'), как пример товары для Shopkeeper из отдельной таблицы migx, или нужно вывести цепочку крошек для другой страницы.
Пример вызова сниппета `<div class="container">
         <ol class="breadcrumb">
          [[QuickCrumbs?
          &tpl=`Crumb` 
          &selfTpl=`Crumb` 
          &siteStartTpl=`Crumb` 
          &separator=`` 
          &hideEmptyContainers=`0` 
          &showSiteStart=`1` 
          &resourceId=`[[*resource_id]]`]]
          <li class="active">[[*pagetitle]]</li>
         </ol></div>`
